### PR TITLE
Add support for  long-running service by defining a query interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A [Prometheus](https://prometheus.io/download/) Exporter/Collector for [ChinaCac
     + `CHINACACHE_USER`
     + `CHINACACHE_PASS`
     + `CHINACACHE_CHANNEL_IDS`
+    + `CHINACACHE_INTERVAL` (optional query interval in [Golang duration format][1]. By default, fetch metrics once and exit)
     + `PUSHGATEWAY` (default for the docker image: http://localhost:9091)
     + `QUERYTIME` (optional)
 2. have Prometheus [downloaded](https://prometheus.io/download/) and installed locally
@@ -94,3 +95,5 @@ A [Prometheus](https://prometheus.io/download/) Exporter/Collector for [ChinaCac
     + Labels:
         * channel = [one of the available channel IDs]
         * StatusCode = [200|404|...]
+
+[1]: https://golang.org/pkg/time/#ParseDuration

--- a/main.go
+++ b/main.go
@@ -3,39 +3,59 @@ package main
 import (
 	"log"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/push"
 )
 
 var (
 	// User-defined Environment-Variables
-	pushGateway = os.Getenv("PUSHGATEWAY")
-	user        = os.Getenv("CHINACACHE_USER")
-	pass        = os.Getenv("CHINACACHE_PASS")
-	channelIDs  = os.Getenv("CHINACACHE_CHANNEL_IDS") // given a comma-separated list of available channel-ids for the specified chinacache user
-	querytime   = os.Getenv("QUERYTIME")
+	pushGateway   = os.Getenv("PUSHGATEWAY")
+	user          = os.Getenv("CHINACACHE_USER")
+	pass          = os.Getenv("CHINACACHE_PASS")
+	channelIDs    = os.Getenv("CHINACACHE_CHANNEL_IDS") // given a comma-separated list of available channel-ids for the specified chinacache user
+	queryInterval = os.Getenv("CHINACACHE_INTERVAL")
+	querytime     = os.Getenv("QUERYTIME")
 )
 
 func main() {
-
 	// check if all the necessary environment-variables were provided and are not empty
 	if user == "" || pass == "" || pushGateway == "" || channelIDs == "" {
 		log.Fatal("error: Please provide the environment-variables PUSHGATEWAY, CHINACACHE_USER, CHINACACHE_PASS, CHINACACHE_CHANNEL_IDS (comma-separated list) and QUERYTIME (minutes)")
 		return
 	}
 
+	interval, err := time.ParseDuration(queryInterval)
+	if err != nil {
+		// Fetch values once and exit
+		interval = 0
+	}
+
 	// create new client and hand it over to create a new collector
 	client := NewChinaCacheClient(user, pass, channelIDs, querytime)
 	collector := NewChinaCacheCollector(client)
 
-	// push the metrics exposed by the collector
-	err := push.AddCollectors(
-		"ChinaCachePush",
-		nil,
-		pushGateway,
-		collector,
-	)
+	for {
+		// push the metrics exposed by the collector
+		err := push.AddCollectors(
+			"ChinaCachePush",
+			nil,
+			pushGateway,
+			collector,
+		)
+		if err != nil {
+			log.Printf("Could not push metrics: %s\n", err)
+		}
+
+		if interval == 0 {
+			break
+		} else {
+			time.Sleep(interval)
+		}
+	}
+
+	// Exit with non-zero statuscode if last fetch resulted in error
 	if err != nil {
-		log.Fatal("error: couldn't add collector to push metrics!\n", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Currently we run the exporter as a batch job in [nomad](https://www.nomadproject.io/).
This has two drawbacks:

* A [periodic stanza](https://www.nomadproject.io/docs/job-specification/periodic.html) has to be added to the config.  
Not everybody is familiar with the syntax of cron expressions, which can lead to confusion about when the job is running.
* Previous runs clutter the logs until they get cleaned up by the nomad garbage collector and can obstruct the view of currently running jobs.

This PR adds the possibility to run the exporter as a long lived service by defining a query interval as an environment variable (e.g. `CHINCACACHE_INTERVAL=1m` would run one query every minute).
To preserve the previous behavior, the exporter will only run once and exit if this environment variable is not set.
